### PR TITLE
output necessary values for local settings

### DIFF
--- a/infra/core/ai/cognitive-services.bicep
+++ b/infra/core/ai/cognitive-services.bicep
@@ -84,5 +84,9 @@ resource chatModelDeployment 'Microsoft.CognitiveServices/accounts/deployments@2
 output aiServicesName string = aiServices.name
 output aiServicesId string = aiServices.id
 output aiServicesEndpoint string = aiServices.properties.endpoint
+output azureOpenAIServiceEndpoint string = 'https://${aiServices.properties.customSubDomainName}.openai.azure.com/'
 output embeddingDeploymentName string = embeddingModelDeployment.name
 output chatDeploymentName string = chatModelDeployment.name 
+@description('Primary key for the AI Services account.')
+@secure()
+output primaryKey string = aiServices.listKeys().key1

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -231,12 +231,27 @@ module api './app/api.bicep' = {
   }
 }
 
-// App outputs
-output APPLICATIONINSIGHTS_CONNECTION_STRING string = monitoring.outputs.applicationInsightsConnectionString
-output AZURE_LOCATION string = location
-output AZURE_TENANT_ID string = tenant().tenantId
-output SERVICE_API_NAME string = api.outputs.SERVICE_API_NAME
-output AZURE_FUNCTION_NAME string = api.outputs.SERVICE_API_NAME
-output COSMOS_ENDPOINT string = cosmosDb.outputs.documentEndpoint
-output OPENAI_ENDPOINT string = openai.outputs.aiServicesEndpoint
+// ==================================
+// Outputs
+// ==================================
+// Define outputs needed specifically for configuring local.settings.json
+// Use 'azd env get-values' to retrieve these after provisioning.
+// WARNING: Secrets (Keys, Connection Strings) are output directly and will be visible in deployment history.
+// Output names directly match the corresponding keys in local.settings.json for easier mapping.
+
+@description('Cosmos DB connection string (includes key). Output name matches the COSMOS_CONN key in local settings.')
+output COSMOS_CONN string = cosmosDb.outputs.connectionString
+
+@description('Connection string for the Azure AI Project. Output name matches the PROJECT_CONNECTION_STRING key in local settings.')
 output PROJECT_CONNECTION_STRING string = aiProject.outputs.projectConnectionString
+
+@description('Endpoint for Azure OpenAI services. Output name matches the AZURE_OPENAI_ENDPOINT key in local settings.')
+output AZURE_OPENAI_ENDPOINT string = openai.outputs.azureOpenAIServiceEndpoint
+
+@description('Primary key for Azure OpenAI services. Output name matches the AZURE_OPENAI_KEY key in local settings.')
+// @secure() - issue with latest bicep version, set secure in cognitive services module
+output AZURE_OPENAI_KEY string = openai.outputs.primaryKey
+
+@description('Name of the deployed Azure Function App.')
+output AZURE_FUNCTION_NAME string = api.outputs.SERVICE_API_NAME // Function App Name
+

--- a/src/local.settings.example.json
+++ b/src/local.settings.example.json
@@ -11,7 +11,7 @@
     "AGENTS_MODEL_DEPLOYMENT_NAME": "gpt-4o",
     "COSMOS_CONN": "AccountEndpoint=https://<cosmos-account-name>.documents.azure.com:443/;AccountKey=<cosmos-account-key>;",
     "PROJECT_CONNECTION_STRING": "<region>.api.azureml.ms;<workspace-id>;<project-name>;<project-name>",
-    "AZURE_OPENAI_ENDPOINT": "https://ai-<uri-from-ai-foundry-models-page>.openai.azure.com/",
-    "AZURE_OPENAI_KEY": "<api-key-from-ai-foundry-models-page>"
+    "AZURE_OPENAI_ENDPOINT": "https://<service-id>.openai.azure.com/",
+    "AZURE_OPENAI_KEY": "<your-azure-openai-key>"
   }
 }


### PR DESCRIPTION
Makes the Azure OpenAI endpoint and primary key available as outputs from the deployment. This allows them to be easily retrieved and used in other applications or configurations, such as setting up the local development environment via `azd env get-values`. Updates the example local settings to reflect the new output names.
