### PR TITLE
Refactors devcontainer and grants user access

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,10 +6,7 @@
   "features": {
     "ghcr.io/devcontainers/features/azure-cli:1": {},
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
-    "ghcr.io/devcontainers/features/node:1": { "version": "lts" },
-
-    // Starts Azurite (blob/queue/table) automatically on container boot
-    "ghcr.io/devcontainers/features/azurite:1": {}
+    "ghcr.io/devcontainers/features/node:1": { "version": "lts" }
   },
 
   // ── Port forwards ───────────────────────────────────────────────────────
@@ -25,8 +22,7 @@
       "extensions": [
         "ms-azuretools.vscode-azurefunctions",
         "ms-azuretools.vscode-docker",
-        "GitHub.copilot",
-        "Azurite.azurite" // UI & table explorer
+        "GitHub.copilot"
       ]
     }
   },

--- a/.devcontainer/start.sh
+++ b/.devcontainer/start.sh
@@ -12,29 +12,6 @@ if [[ -f .venv/bin/activate ]]; then
   source .venv/bin/activate
 fi
 
-# ── Cosmos DB Linux emulator ──────────────────────────────────────────────
-# Runs in gateway mode so the default connection string against localhost works.
-if ! docker ps --filter "name=cosmos-emu" --format '{{.Names}}' | grep -q cosmos-emu; then
-  echo "▶ Starting Cosmos DB emulator container"
-  docker run -d --name cosmos-emu \
-    -p 8081:8081 -p 8900:8900 \
-    mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator
-fi
-
-# ── Azurite storage emulator (blob / queue / table) ───────────────────────
-if ! pgrep -f "azurite.*--location" >/dev/null; then
-  echo "▶ Starting Azurite storage emulator"
-  AZURITE_DATA_DIR="$REPO_ROOT/.azurite"
-  mkdir -p "$AZURITE_DATA_DIR"
-  nohup azurite --silent \
-        --location "$AZURITE_DATA_DIR" \
-        --blobHost 0.0.0.0 --queueHost 0.0.0.0 --tableHost 0.0.0.0 \
-        > "$AZURITE_DATA_DIR/azurite.log" 2>&1 &
-fi
-
-# The Functions host needs a storage connection string even when using Azurite.
-export AzureWebJobsStorage="UseDevelopmentStorage=true"
-
 # ── Azure Functions runtime ───────────────────────────────────────────────
 echo "▶ func start (port 7071)"
 func start --python --no-build --port 7071

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -94,6 +94,17 @@ module blobRoleAssignmentApi 'app/rbac/storage-Access.bicep' = {
   }
 }
 
+// Allow user access to blob storage
+module userBlobRoleAssignmentApi 'app/rbac/storage-Access.bicep' = {
+  name: 'userBlobRoleAssignmentApi'
+  scope: rg
+  params: {
+    storageAccountName: storage.outputs.name
+    roleDefinitionID: StorageBlobDataOwner
+    principalID: deployer().objectId
+  }
+}
+
 // Allow access from api to queue storage using a managed identity
 module queueRoleAssignmentApi 'app/rbac/storage-Access.bicep' = {
   name: 'queueRoleAssignmentapi'

--- a/src/function_app.py
+++ b/src/function_app.py
@@ -122,7 +122,7 @@ tool_properties_code_style_json = json.dumps([prop.to_dict() for prop in tool_pr
 # HTTP endpoint for saving snippets
 # This is accessible via standard HTTP POST requests
 @app.route(route="snippets", methods=["POST"], auth_level=func.AuthLevel.FUNCTION)
-@app.embeddings_input(arg_name="embeddings", input="{code}", input_type="rawText", model="%EMBEDDING_MODEL_DEPLOYMENT_NAME%")
+@app.embeddings_input(arg_name="embeddings", input="{code}", input_type="rawText", embeddingsModel="%EMBEDDING_MODEL_DEPLOYMENT_NAME%")
 async def http_save_snippet(req: func.HttpRequest, embeddings: str) -> func.HttpResponse:
     """
     HTTP trigger function to save a code snippet with its vector embedding.
@@ -199,7 +199,7 @@ async def http_save_snippet(req: func.HttpRequest, embeddings: str) -> func.Http
     description="Saves a given code snippet. It can take a snippet name, the snippet content, and an optional project ID. Embeddings are generated for the content to enable semantic search. The LLM should provide 'snippetname' and 'snippet' when intending to save.",
     toolProperties=tool_properties_save_snippets_json,
 )
-@app.embeddings_input(arg_name="embeddings", input="{arguments.snippet}", input_type="rawText", model="%EMBEDDING_MODEL_DEPLOYMENT_NAME%")
+@app.embeddings_input(arg_name="embeddings", input="{arguments.snippet}", input_type="rawText", embeddingsModel="%EMBEDDING_MODEL_DEPLOYMENT_NAME%")
 async def mcp_save_snippet(context: str, embeddings: str) -> str:
     """
     MCP tool to save a code snippet with vector embedding.


### PR DESCRIPTION
- Updates the devcontainer configuration by removing the Azurite and Cosmos DB emulators. This streamlines the development environment and avoids potential conflicts.
- Grants the user (deployer) access to the blob storage account via RBAC. This enables the user to manage and access blob data directly.
- Renames the 'model' parameter to 'embeddingsModel' in the embeddings input decorator to align with the recent breaking change in the Azure Function embeddings extension. This ensures proper functionality and prevents errors.