### PR TITLE
Refactors storage connection string handling

### DIFF
--- a/infra/app/rbac/storage-Access.bicep
+++ b/infra/app/rbac/storage-Access.bicep
@@ -1,6 +1,7 @@
 param principalID string
 param roleDefinitionID string
 param storageAccountName string
+param principalType string = 'ServicePrincipal' // Workaround for https://learn.microsoft.com/en-us/azure/role-based-access-control/role-assignments-template#new-service-principal
 
 resource storageAccount 'Microsoft.Storage/storageAccounts@2021-09-01' existing = {
   name: storageAccountName
@@ -13,7 +14,7 @@ resource storageRoleAssignment 'Microsoft.Authorization/roleAssignments@2020-04-
   properties: {
     roleDefinitionId: resourceId('Microsoft.Authorization/roleDefinitions', roleDefinitionID)
     principalId: principalID
-    principalType: 'ServicePrincipal' // Workaround for https://learn.microsoft.com/en-us/azure/role-based-access-control/role-assignments-template#new-service-principal
+    principalType: principalType
   }
 }
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -96,17 +96,6 @@ module blobRoleAssignmentApi 'app/rbac/storage-Access.bicep' = {
   }
 }
 
-// Allow user access to blob storage
-module userBlobRoleAssignmentApi 'app/rbac/storage-Access.bicep' = {
-  name: 'userBlobRoleAssignmentApi'
-  scope: rg
-  params: {
-    storageAccountName: storage.outputs.name
-    roleDefinitionID: StorageBlobDataOwner
-    principalID: deployer().objectId
-  }
-}
-
 // Allow access from api to queue storage using a managed identity
 module queueRoleAssignmentApi 'app/rbac/storage-Access.bicep' = {
   name: 'queueRoleAssignmentapi'
@@ -266,5 +255,4 @@ output AZURE_OPENAI_KEY string = openai.outputs.primaryKey
 output AZURE_FUNCTION_NAME string = api.outputs.SERVICE_API_NAME // Function App Name
 
 @description('Connection string for the Azure Storage Account. Output name matches the AzureWebJobsStorage key in local settings.')
-@secure()
-output AZUREWEBJOBSSTORAGE string = 'DefaultEndpointsProtocol=https;AccountName=${storageAccountActualName};AccountKey=${listKeys(resourceId('Microsoft.Storage/storageAccounts', storageAccountActualName), '2022-09-01').keys[0].value};EndpointSuffix=core.windows.net'
+output AZUREWEBJOBSSTORAGE string = storage.outputs.primaryBlobEndpoint

--- a/scripts/generate-settings.ps1
+++ b/scripts/generate-settings.ps1
@@ -14,7 +14,7 @@ $jsonContent = @"
 {
   "IsEncrypted": false,
   "Values": {
-    "AzureWebJobsStorage": "$AZUREWEBJOBSSTORAGE",
+    "AzureWebJobsSecretStorageType": "files",
     "FUNCTIONS_WORKER_RUNTIME": "python",
     "PYTHON_ENABLE_WORKER_EXTENSIONS": "True",
     "COSMOS_DATABASE_NAME": "dev-snippet-db",

--- a/scripts/generate-settings.sh
+++ b/scripts/generate-settings.sh
@@ -14,7 +14,7 @@ cat > src/local.settings.json << EOF
 {
   "IsEncrypted": false,
   "Values": {
-    "AzureWebJobsStorage": "$AZUREWEBJOBSSTORAGE",
+    "AzureWebJobsSecretStorageType": "files",
     "FUNCTIONS_WORKER_RUNTIME": "python",
     "PYTHON_ENABLE_WORKER_EXTENSIONS": "True",
     "COSMOS_DATABASE_NAME": "dev-snippet-db",


### PR DESCRIPTION
- Simplifies storage account connection string management by retrieving the primary blob endpoint directly from the storage account outputs, enhancing security and reducing complexity.
- Changes the `AzureWebJobsStorage` key to `AzureWebJobsSecretStorageType` in local settings files, indicating that secrets will be stored in files, for enhanced security and portability.
- Removes the user blob role assignment module as no longer needed.