### PR TITLE
Fixes: Corrects typo in decorator argument

### DIFF
--- a/src/function_app.py
+++ b/src/function_app.py
@@ -122,7 +122,7 @@ tool_properties_code_style_json = json.dumps([prop.to_dict() for prop in tool_pr
 # HTTP endpoint for saving snippets
 # This is accessible via standard HTTP POST requests
 @app.route(route="snippets", methods=["POST"], auth_level=func.AuthLevel.FUNCTION)
-@app.embeddings_input(arg_name="embeddings", input="{code}", input_type="rawText", embeddingsModel="%EMBEDDING_MODEL_DEPLOYMENT_NAME%")
+@app.embeddings_input(arg_name="embeddings", input="{code}", input_type="rawText", embeddings_model="%EMBEDDING_MODEL_DEPLOYMENT_NAME%")
 async def http_save_snippet(req: func.HttpRequest, embeddings: str) -> func.HttpResponse:
     """
     HTTP trigger function to save a code snippet with its vector embedding.


### PR DESCRIPTION
Corrects a typo in the `embeddings_input` decorator.

The `embeddings_model` argument was misspelled as `embeddingsModel`. This change ensures the correct argument name is used.