### PR TITLE
fix: Updated mcp.json and host.json to support streamable http - Fixes #46

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -14,15 +14,15 @@
   ],
   "servers": {
     "remote-snippy": {
-      "type": "sse",
-      "url": "https://${input:functionapp-name}.azurewebsites.net/runtime/webhooks/mcp/sse",
+      "type": "http",
+      "url": "https://${input:functionapp-name}.azurewebsites.net/runtime/webhooks/mcp/",
       "headers": {
         "x-functions-key": "${input:functions-mcp-extension-system-key}"
       }
     },
     "local-snippy": {
-      "type": "sse",
-      "url": "http://localhost:7071/runtime/webhooks/mcp/sse"
+      "type": "http",
+      "url": "http://localhost:7071/runtime/webhooks/mcp/"
     }
   }
 }

--- a/src/host.json
+++ b/src/host.json
@@ -12,7 +12,17 @@
     }
   },
   "extensionBundle": {
-    "id": "Microsoft.Azure.Functions.ExtensionBundle.Experimental",
-    "version": "[4.*, 5.0.0)"
-  }
+    "id": "Microsoft.Azure.Functions.ExtensionBundle.Preview",
+    "version": "[4.0.0, 5.0.0)"
+  },
+  "extensions": {
+    "mcp": {
+      "instructions": "Snippy is an intelligent code snippet service with AI-powered analysis. Available tools: save_snippet (save code with vector embeddings), get_snippet (retrieve saved snippets by name), code_style (generate style guides from snippets), and deep_wiki (create comprehensive documentation). Use save_snippet with 'snippetname' and 'snippet' parameters, optionally include 'projectid'. Retrieve snippets using get_snippet with 'snippetname'. Generate documentation with code_style or deep_wiki, optionally providing 'chathistory' and 'userquery' for context.",
+      "serverName": "Snippy",
+      "serverVersion": "2.0.0",
+      "messageOptions": {
+        "useAbsoluteUriForEndpoint": false
+      }
+    }    
+  }  
 }


### PR DESCRIPTION
## Description
Updated the MCP server instructions in host.json to replace placeholder text with comprehensive usage instructions for Snippy's AI-powered code snippet tools.

## Changes
- Replaced "Some test instructions on how to use the server" with detailed MCP tool descriptions
- Added clear descriptions for save_snippet, get_snippet, code_style, and deep_wiki tools  
- Included parameter guidance and usage instructions for better user experience

## Testing
- [ ] Verified host.json syntax is valid
- [ ] Confirmed MCP server instructions are comprehensive and accurate

Fixes #46